### PR TITLE
Build the package without its runtime dependencies installed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       # publish a version nobody can trace back to a commit
       - name: Verify the tag matches the packaged version
         run: |
-          packaged=$(python -c 'from anvilfs.__about__ import __version__; print(__version__)')
+          packaged=$(python -c "about = {}; exec(open('anvilfs/__about__.py').read(), about); print(about['__version__'])")
           if [ "$GITHUB_REF_NAME" != "$packaged" ]; then
             echo "::error::tag $GITHUB_REF_NAME does not match anvilfs/__about__.py version $packaged"
             exit 1

--- a/anvilfs/__init__.py
+++ b/anvilfs/__init__.py
@@ -1,8 +1,6 @@
 import configparser
 import inspect
 
-from urllib3.util.retry import Retry
-
 # Both shims below work around dependencies that no longer import on modern
 # runtimes and have no fixed release. They run here rather than in the modules
 # that trigger them so they apply ahead of every submodule, whatever the import
@@ -29,11 +27,22 @@ def _translate_method_whitelist(original_init):
     return retry_init
 
 
-# getm builds Retry(method_whitelist=["HEAD", "GET"]) at import time. urllib3
-# renamed that argument to allowed_methods in 1.26 and removed it in 2.0, so
-# translate the keyword; pinning urllib3<2 is not an option in a Galaxy
-# process. Remove once getm ships a fix; 0.0.5, the latest, still uses the old
-# name.
-if not getattr(Retry.__init__, "anvilfs_translates_method_whitelist", False):
-    if "method_whitelist" not in inspect.signature(Retry.__init__).parameters:
-        Retry.__init__ = _translate_method_whitelist(Retry.__init__)
+def _install_retry_shim():
+    # getm builds Retry(method_whitelist=["HEAD", "GET"]) at import time.
+    # urllib3 renamed that argument to allowed_methods in 1.26 and removed it
+    # in 2.0, so translate the keyword; pinning urllib3<2 is not an option in a
+    # Galaxy process. Remove once getm ships a fix; 0.0.5, the latest, still
+    # uses the old name.
+    try:
+        from urllib3.util.retry import Retry
+    except ImportError:
+        # absent while the package is being built, when nothing needs shimming
+        return
+    if getattr(Retry.__init__, "anvilfs_translates_method_whitelist", False):
+        return
+    if "method_whitelist" in inspect.signature(Retry.__init__).parameters:
+        return
+    Retry.__init__ = _translate_method_whitelist(Retry.__init__)
+
+
+_install_retry_shim()

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,14 @@ https://packaging.python.org/guides/distributing-packages-using-setuptools/
 from setuptools import setup, find_packages
 import pathlib
 
-from anvilfs.__about__ import __version__
-
 here = pathlib.Path(__file__).parent.resolve()
+
+# read rather than import: importing anvilfs pulls in runtime dependencies
+# that are not installed while the package is being built
+__about__ = {}
+_about_path = here / 'anvilfs' / '__about__.py'
+exec(_about_path.read_text(encoding='utf-8'), __about__)
+__version__ = __about__['__version__']
 
 # Get the long description from the README file
 long_description = (here / 'README.md').read_text(encoding='utf-8')


### PR DESCRIPTION
## Problem

The 0.2.10 tag failed to publish. My fault in #30: adding the urllib3 import to `anvilfs/__init__.py` made importing the package require a runtime dependency, and both `setup.py:11` and the release workflow's tag check read `__version__` by importing `anvilfs`. Neither environment has runtime dependencies installed.

```
File ".../anvilfs/__init__.py", line 4, in <module>
    from urllib3.util.retry import Retry
ModuleNotFoundError: No module named 'urllib3'
```

This was not only a CI problem. `setup.py` is what pip runs, so building or installing from source was broken the same way — it just surfaced in the release job first.

## Change

- **`setup.py`** reads `anvilfs/__about__.py` instead of importing the package. Importing your own package to read its version is the long-standing packaging anti-pattern for exactly this reason; reading it keeps the single source without pulling dependencies into the build.
- **`.github/workflows/release.yml`** does the same in the tag check.
- **`anvilfs/__init__.py`** tolerates urllib3 being absent, so importing the package never fails over a shim for a dependency that isn't installed. The retry shim moved into a small function to make the early return readable.

## Verification

In a venv containing only `build` — no runtime dependencies, matching CI:

```
$ python -c "about = {}; exec(open('anvilfs/__about__.py').read(), about); print(about['__version__'])"
0.2.10
$ python -m build
Successfully built fs_anvilfs-0.2.10.tar.gz and fs_anvilfs-0.2.10-py3-none-any.whl
$ python -c "import anvilfs"      # no urllib3 present
OK
```

And where urllib3 2.7.0 is present, unchanged from #30:

| check | result |
|---|---|
| legacy `method_whitelist=` | → `allowed_methods=['HEAD','GET']` |
| modern `allowed_methods=` | unchanged |
| 5 × `importlib.reload` | no recursion |

## Release

0.2.10 never published, so the version number is unused. The tag will be moved to this commit rather than burning 0.2.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
